### PR TITLE
Fixed an unwanted infinite loop.

### DIFF
--- a/06-queues/projects/starter/lib/ring_buffer.dart
+++ b/06-queues/projects/starter/lib/ring_buffer.dart
@@ -20,9 +20,10 @@ class RingBuffer<E> {
     _size++;
   }
 
-  int _advance(int index) {
-    return (index == _list.length - 1) ? 0 : index + 1;
-  }
+  // int _advance(int index) {
+  //   return (index == _list.length - 1) ? 0 : index + 1;
+  // }
+  int _advance(int index) => (index + 1) % _list.length;
 
   E? read() {
     if (isEmpty) return null;
@@ -38,14 +39,14 @@ class RingBuffer<E> {
   String toString() {
     final text = StringBuffer();
     text.write('[');
-    int index = _readIndex;
-    while (index != _writeIndex) {
+
+    for (int index = _readIndex; index != _writeIndex; index = _advance(index)) {
       if (index != _readIndex) {
         text.write(', ');
       }
-      text.write(_list[index % _list.length]);
-      index++;
+      text.write(_list[index]);
     }
+
     text.write(']');
     return text.toString();
   }

--- a/06-queues/projects/starter/lib/ring_buffer.dart
+++ b/06-queues/projects/starter/lib/ring_buffer.dart
@@ -40,7 +40,8 @@ class RingBuffer<E> {
     final text = StringBuffer();
     text.write('[');
 
-    for (int index = _readIndex; index != _writeIndex; index = _advance(index)) {
+    int noe = _size; // noe - Number Of Elements
+    for (int index = _readIndex; noe > 0; index = _advance(index), --noe) {
       if (index != _readIndex) {
         text.write(', ');
       }


### PR DESCRIPTION
In the case where the _writeIndex < _readIndex the loop will not stop.

The pull request solves this problem.

For example the below code will not stop running 

```
import 'queue.dart';

void main(List<String> args) {
  final q = QueueRingBuffer<String>(3);
  q.enqueue('Ray');
  q.enqueue('Brain');
  print(q);

  q.dequeue();
  print(q);
}```

assuming QueueRingBuffer is based on the old RingBuffer code.